### PR TITLE
slightly different approach...

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  "sourceMaps": "true",
-  "stage": 2
+  "sourceMaps": true,
+  "stage": 2,
+  "optional": ["runtime"]
 }
-

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
   },
   "scripts": {
     "test": "./test/runtests.sh",
-    "compile": "rm -rf lib/ && ./node_modules/.bin/babel -sd lib/ src/",
-    "pretest": "npm run compile",
+    "compile": "rm -rf lib/ && babel -sd lib/ src/",
     "prepublish": "npm run compile"
   },
   "repository": {
@@ -29,11 +28,11 @@
   "homepage": "https://github.com/taskcluster/taskcluster-loader",
   "dependencies": {
     "assume": "^1.3.1",
-    "babel": "^5.8.23",
+    "babel-runtime": "^5.8.23",
     "debug": "^2.2.0",
     "lodash": "^3.10.1",
     "promise": "^7.0.4",
-    "toposort": "^0.2.12"
+    "topo-sort": "^1.0.0"
   },
   "devDependencies": {
     "babel": "^5.8.23",

--- a/src/loader.js
+++ b/src/loader.js
@@ -7,26 +7,26 @@ let TopoSort = require('topo-sort');
 
 /** Validate component definition */
 function validateComponent(def, name) {
+  let e = "Invalid component definition: " + name;
   // Check that it's an object
   if (typeof(def) !== 'object' && def !== null && def !== undefined) {
-    throw new Error("Invalidate component definition: " + name);
+    throw new Error(e + ' must be an object, null or undefined');
   }
   // Check that is object has a setup function
   if (!(def.setup instanceof Function)) {
-    throw new Error("Invalidate component definition: " + name);
+    throw new Error(e + ' is missing setup function');
   }
   // If requires is defined, then we check that it's an array of strings
   if (def.requires) {
     if (!(def.requires instanceof Array)) {
-      throw new Error("Invalidate component definition: " + name);
+      throw new Error(e + ' if present, requires must be array');
     }
     // Check that all entries in def.requires are strings
     if (!def.requires.every(entry => typeof(entry) === 'string')) {
-      throw new Error("Invalidate component definition: " + name);
+      throw new Error(e + ' all items in requires must be strings');
     }
   }
 }
-
 
 /**
  * Render componentDirectory to dot format for graphviz given a

--- a/src/loader.js
+++ b/src/loader.js
@@ -6,7 +6,7 @@ let _ = require('lodash');
 let TopoSort = require('topo-sort');
 
 /** Check if a value is a flat value or a component definition */
-let isComponent = (def) => {
+function isComponent(def) {
   // Check that it's an object
   if (typeof(def) !== 'object' && def !== null && def !== undefined) {
     return false;
@@ -24,14 +24,14 @@ let isComponent = (def) => {
     return def.requires.every(entry => typeof(entry) === 'string');
   }
   return true;
-};
+}
 
 
 /**
  * Render componentDirectory to dot format for graphviz given a
  * topologically sorted list of components
  */
-let renderGraph = (componentDirectory, sortedComponents) => {
+function renderGraph(componentDirectory, sortedComponents) {
   let dot = [
     '// This graph shows all dependencies for this loader.',
     '// You might find http://www.webgraphviz.com/ useful!',
@@ -51,7 +51,7 @@ let renderGraph = (componentDirectory, sortedComponents) => {
   dot.push('}');
 
   return dot.join('\n');
-};
+}
 
 /*
  * Construct a component loader function.

--- a/src/loader.js
+++ b/src/loader.js
@@ -170,23 +170,23 @@ function loader (componentDirectory, virtualComponents = []) {
     }
 
     // Keep state of loaded components, make the virtual ones immediately loaded
-    let loading = {};
+    let loaded = {};
     for (let vComp of virtualComponents) {
-      loading[vComp] = Promise.resolve(options[vComp]);
+      loaded[vComp] = Promise.resolve(options[vComp]);
     }
 
     // Load a component
     function load(target) {
-      if (!loading[target]) {
+      if (!loaded[target]) {
         var def = componentDirectory[target];
         // If component is a flat value we don't have to call setup
         if (!isComponent(def)) {
-          return loading[target] = Promise.resolve(def);
+          return loaded[target] = Promise.resolve(def);
         }
         // Otherwise we initialize, this won't cause an infinite loop because
         // we've already check that the componentDirectory is a DAG
         let requires = def.requires || [];
-        return loading[target] = Promise.all(requires.map(load)).then(deps => {
+        return loaded[target] = Promise.all(requires.map(load)).then(deps => {
           let ctx = {};
           for(let i = 0; i < deps.length; i++) {
             ctx[def.requires[i]] = deps[i];
@@ -194,7 +194,7 @@ function loader (componentDirectory, virtualComponents = []) {
           return def.setup.call(null, ctx);
         });
       }
-      return loading[target];
+      return loaded[target];
     };
 
     return load(target);

--- a/src/loader.js
+++ b/src/loader.js
@@ -127,6 +127,7 @@ function loader (componentDirectory, virtualComponents = []) {
   assume(_.intersection(
     _.keys(componentDirectory), virtualComponents)
   ).has.length(0);
+  componentDirectory = _.clone(componentDirectory);
 
   // Check for undefined components
   _.forEach(componentDirectory, (def, name) => {
@@ -160,6 +161,7 @@ function loader (componentDirectory, virtualComponents = []) {
   componentDirectory.graphviz = renderGraph(componentDirectory, topoSorted);
 
   return function(target, options = {}) {
+    options = _.clone(options);
     assume(target).is.a('string');
     // Check that all virtual components are defined
     assume(options).is.an('object');

--- a/src/loader.js
+++ b/src/loader.js
@@ -121,7 +121,7 @@ let renderGraph = (componentDirectory, sortedComponents) => {
  * let config = await load('config', {profile: 'test'});
  * ```
  */
-let loader = (componentDirectory, virtualComponents = []) => {
+function loader (componentDirectory, virtualComponents = []) {
   assume(componentDirectory).is.an('object');
   assume(virtualComponents).is.an('array');
   assume(_.intersection(
@@ -154,11 +154,12 @@ let loader = (componentDirectory, virtualComponents = []) => {
   let topoSorted = tsort.sort();
 
   // Add graphviz target, if it doesn't exist, we'll just render it as string
-  if (!componentDirectory.graphviz) {
-    componentDirectory.graphviz = renderGraph(componentDirectory, topoSorted);
+  if (componentDirectory.graphviz || virtualComponents.includes('graphviz')) {
+    throw new Error('graphviz is reserved for an internal component');
   }
+  componentDirectory.graphviz = renderGraph(componentDirectory, topoSorted);
 
-  return (target, options = {}) => {
+  return function(target, options = {}) {
     assume(target).is.a('string');
     // Check that all virtual components are defined
     assume(options).is.an('object');
@@ -173,7 +174,7 @@ let loader = (componentDirectory, virtualComponents = []) => {
     }
 
     // Load a component
-    let load = (target) => {
+    function load(target) {
       if (!loading[target]) {
         var def = componentDirectory[target];
         // If component is a flat value we don't have to call setup

--- a/test/loader_tests.js
+++ b/test/loader_tests.js
@@ -8,7 +8,7 @@ describe('component loader', () => {
     let a = {a: 1};
 
     let load = subject({
-      test: a,
+      test: {setup: () => a},
     });
 
     assume(await load('test')).equals(a);
@@ -151,11 +151,11 @@ describe('component loader', () => {
     let b = {b: 2};
     let c = {c: 2};
     let load = subject({
-      string: 'a-string',
-      object: a,
-      number: 123.456,
-      promise: Promise.resolve(b),
-      func: () => { return c },
+      string: {setup: () => 'a-string'},
+      object: {setup: () => a},
+      number: {setup: () => 123.456},
+      promise: {setup: () => Promise.resolve(b)},
+      func: {setup: ()=> () => { return c }},
       base: {
         requires: ['string', 'object', 'number', 'promise', 'func'],
         setup: async deps => {
@@ -189,7 +189,9 @@ describe('component loader', () => {
         requires: [],
         setup: () => true
       },
-      staticDep1: 'john',
+      staticDep1: {
+        setup: () => 'john'
+      },
       base: {
         requires: ['dep1', 'staticDep1'],
         setup: async deps => {
@@ -220,7 +222,9 @@ describe('component loader', () => {
         requires: [],
         setup: () => true,
       },
-      staticDep1: 'john',
+      staticDep1: {
+        setup: () => 'john'
+      },
       base: {
         requires: ['dep1', 'staticDep1'],
         setup: async deps => {
@@ -232,8 +236,8 @@ describe('component loader', () => {
         requires: ['dep5', 'dep6'],
         setup: () => true,
       },
-      dep5: true,
-      dep6: true,
+      dep5: {setup: () => true},
+      dep6: {setup: () => true},
     });
     let expected = [
       '// This graph shows all dependencies for this loader.',

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,4 @@
+--ui tdd
+--timeout 30s
+--reporter spec
+--compilers js:babel/register


### PR DESCRIPTION
@jhford, you're right about babelrc not being read right...

But:
> "compile": "rm -rf lib/ && babel -sd lib/ src/",

works fine... Try using `which babel` in there... maybe you just didn't have babel installed in the folder for some reason...


--------------
I was very tempted to do more crazy stuff in this PR... But decided that we're probably better off aiming at the bare minimum that we can both agree on...

I'm still open to doing the position arguments for `setup`, but I'm also okay leaving as something we can do in a wrapper... Not a wrapper for `base.loader` but in some auxiliary function that helps you wrap create a component loader...


Regarding the virtual components... I think this proposal is very robust because  we have a lot of upfront checks... IMO, if we have special component loaders that are only used in tests, we can still include them in the default `components.js` file because `server.js` won't load them...

Or we can support the kind of additional component loaders you proposed later if we have solid use-cases for it. I hope we won't. So I've tried to keep this minimalistic.



----
If you like the idea of giving `setup` positional arguments instead of a `deps` dictionary, let me know, and I'll it... it's unfortunately something we can easily add support for in the future...

hmm.. Actually in the future we can just say that a component loader must implement either `setup` or `setup2` if we want to change the calling convention... Granted we would probably give the new a better name than `setup2` :)