### PR TITLE
Show better errors on undefined component

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -178,8 +178,14 @@ function loader(componentDirectory, virtualComponents = []) {
   return function(target, options = {}) {
     options = _.clone(options);
     if (typeof target !== 'string') {
-      new Error(`Target is type ${typeof target}, not string`);
+      throw new Error(`Target is type ${typeof target}, not string`);
     }
+
+    // Check that target is defined
+    if (!componentDirectory[target] && !includes(virtualComponents, target)) {
+      throw new Error(`Target ${target} is not defined`);
+    }
+
     // Check that all virtual components are defined
     if (typeof options !== 'object') {
       throw new Error('options must be an object');

--- a/test/loader_tests.js
+++ b/test/loader_tests.js
@@ -131,6 +131,25 @@ describe('component loader', () => {
     assume(called).is.true();
   });
 
+  it('should fail loading a nonexistent component', async () => {
+    let load = subject({
+      base: {
+        requires: [],
+        setup: () => {}
+      }
+    });
+
+    try {
+      await load('does-not-exist');
+    } catch (e) {
+      if (!e.message.match(/is not defined/)) {
+        throw e;
+      }
+      return; // Ignore expected error
+    }
+    assert(false, 'Expected an exception')
+  });
+
 
   it('should detect and bail on cyclic dependency', async () => {
     try {


### PR DESCRIPTION
This improves the error message whne you call load(..) with a component
that does not exist.