### PR TITLE
Expand README slightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,56 @@
 # Taskcluster Component Loader
 
-Creates a component loader from a set of inter-dependent component definitions.
+This library provides a means of loading application "components", each of
+which can depend on other components.  This makes application startup more
+modular and flexible.  It also enables dependency injection during tests.
+
+It is used to run all TaskCluster microservices.
+
+## Components
+
 Each component definition specifies:
+
   * Name of the component,
   * Required components to be instantiated first, and,
   * How to asynchronously load the component.
 
-Given a set of these definitions, `taskcluster-lib-loader` will ensure that
-definitions are valid, that dependencies forms a directed acylic graph (DAG),
-and return a method `load(componentName, overwrites)` which will asynchronously
-load a component by `componentName`. Before loading the component it will
-load all dependent components not specified in the `overwrites` dictionary.
+All of this is specified as properties of the components object.  A server
+component might be defined like this:
 
-**Example**
+```js
+  // Definition of 'server' component, notice that components listed in
+  // `required` are destructured in the argument to `setup`.
+  server: {
+    required: ['port'],
+    setup: async ({port}) => {
+      let server = http.createServer();
+      await new Promise((accept, reject) => {
+        server.once('error', reject);
+        server.once('listening', accept);
+        server.listen(ctx.port);
+      });
+      return server;
+    }
+  },
+```
+
+## Loading
+
+The loader components are all handed to this library, which returns a
+`load(componentname, overwrites)` function.  While creating this function, the
+library will also ensure that definitions are valid and that the components
+form a directed acylic graph (DAG).
+
+Calling the `load` function with a component name will return the result of
+that component's setup function (after recursively setting up any of the
+component's requirements).   All components are loaded asynchronously: a
+component's `setup` function may return a Promise which will be resolved before
+setting up components that depend on it.
+
+The following example creates a server, where the port number is provided by
+another component.  Note that the `server` component's `setup` method is
+asynchronous, and that `await` is used with the `load` method invocation.
+
 ```js
 let loader = require('taskcluster-lib-loader');
 
@@ -46,7 +84,9 @@ let load = loader({
 let server = await load('server');
 ```
 
-With `overwrites` you can replace a component, this is particularly useful in
+## Overwrites and Virtual Components
+
+With `overwrites` you can replace a component.  This is particularly useful in
 tests where you may want to inject a mock component, but still load the same
 end result. In the example we could overwrite `port` using:
 
@@ -90,21 +130,38 @@ let load = loader({
     }
   }
 
-  // Virtual components must always be specified for `load` to work
+  // Virtual components that must always be specified for `load` to work
 }, ['port']);
 
 // Create express (here we're forced to specify port)
 let server = await load('express', {port: 80});
 ```
 
-As a neat little the load has a default target `graphviz` which returns a
-graphical representation of the dependency graph in graphviz format.
+As a neat little treat, the load has a default target `graphviz` which returns
+a representation of the dependency graph in graphviz's dot format. This
+representation can be rendered using the graphviz tool.
 
-**Remark** the `load` function doesn't have any side-effects on it's own, which
+**Remark** the `load` function doesn't have any side-effects on its own, which
 means that if you call `load('server')` twice you'll get two different
 instantiations of the `server` component and all of its dependencies. This is
 particularly useful for getting a fresh component between tests.
 
+## Advice
+
 We generally recommend one component loader per project, and that you expose
 it in an executable such that you do `node server.js <component>` to start a
-process running the specified component.
+process running the specified component.  A handy way to run the loader on startup,
+given both the profile ($NODE_ENV) and process (target component):
+
+```js
+// If this file is executed launch component from first argument
+if (!module.parent) {
+  load(process.argv[2], {
+    process: process.argv[2],
+    profile: process.env.NODE_ENV,
+  }).catch(err => {
+    console.log(err.stack);
+    process.exit(1);
+  });
+}
+```


### PR DESCRIPTION
This doesn't add any content that wasn't already present, but explains
it a little more thoroughly, with an eye toward helping newcomers
wondering what this crazy 'loader' thing is.

This is part of a concerted effort to put full library docs in the README. The README appears on github, on npmjs.org, and on docs.taskcluster.net, so it makes sense to put the canonical docs there.