### PR TITLE
Add debug logging of component loading

### DIFF
--- a/test/loader_tests.js
+++ b/test/loader_tests.js
@@ -171,6 +171,25 @@ describe('component loader', () => {
     assert(false, 'Expected an exception');
   });
 
+  it('should fail when a setup function returns a rejected promise', async () => {
+    let load = subject({
+      fail: {
+        requires: [],
+        setup: () => Promise.reject(new Error('uhoh!')),
+      },
+    });
+
+    try {
+      await load('fail');
+    } catch (e) {
+      if (!e.message.match(/uhoh!/)) {
+        throw e;
+      }
+      return; // Ignore expected error
+    }
+    assert(false, 'Expected an exception');
+  });
+
   it('should fail when an async setup function fails', async () => {
     let load = subject({
       fail: {

--- a/test/loader_tests.js
+++ b/test/loader_tests.js
@@ -150,6 +150,48 @@ describe('component loader', () => {
     assert(false, 'Expected an exception');
   });
 
+  it('should fail when a sync setup function fails', async () => {
+    let load = subject({
+      fail: {
+        requires: [],
+        setup: () => {
+          throw new Error('uhoh!');
+        },
+      },
+    });
+
+    try {
+      await load('fail');
+    } catch (e) {
+      if (!e.message.match(/uhoh!/)) {
+        throw e;
+      }
+      return; // Ignore expected error
+    }
+    assert(false, 'Expected an exception');
+  });
+
+  it('should fail when an async setup function fails', async () => {
+    let load = subject({
+      fail: {
+        requires: [],
+        setup: async () => {
+          throw new Error('uhoh!');
+        },
+      },
+    });
+
+    try {
+      await load('fail');
+    } catch (e) {
+      if (!e.message.match(/uhoh!/)) {
+        throw e;
+      }
+      return; // Ignore expected error
+    }
+    assert(false, 'Expected an exception');
+  });
+
   it('should detect and bail on cyclic dependency', async () => {
     try {
       let load = subject({


### PR DESCRIPTION
When writing tests, if something fails to load, the stack doesn't give
much information - not even what component was being loaded.  A little
debug output can help determine exactly what was happening when the
failure occurred.