### PR TITLE
Intercept errors to print debugging information

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -3,6 +3,7 @@ let assume = require('assume');
 let Promise = require('promise');
 let _ = require('lodash');
 let TopoSort = require('topo-sort');
+let debug = require('debug')('taskcluster-lib-loader');
 
 // see babel issue 2215
 function includes(a, v) {

--- a/test/loader_tests.js
+++ b/test/loader_tests.js
@@ -171,12 +171,54 @@ describe('component loader', () => {
     assert(false, 'Expected an exception');
   });
 
-  it('should fail when an async setup function fails', async () => {
+  it('should fail when an async setup function fails (async function)', async () => {
     let load = subject({
       fail: {
         requires: [],
         setup: async () => {
           throw new Error('uhoh!');
+        },
+      },
+    });
+
+    try {
+      await load('fail');
+    } catch (e) {
+      if (!e.message.match(/uhoh!/)) {
+        throw e;
+      }
+      return; // Ignore expected error
+    }
+    assert(false, 'Expected an exception');
+  });
+
+  it('should fail when an async setup function fails (async function which returns promise)', async () => {
+    let load = subject({
+      fail: {
+        requires: [],
+        setup: async () => {
+          return Promise.reject(new Error('uhoh!'));
+        },
+      },
+    });
+
+    try {
+      await load('fail');
+    } catch (e) {
+      if (!e.message.match(/uhoh!/)) {
+        throw e;
+      }
+      return; // Ignore expected error
+    }
+    assert(false, 'Expected an exception');
+  });
+
+  it('should fail when an async setup function fails (function which returns promise)', async () => {
+    let load = subject({
+      fail: {
+        requires: [],
+        setup: () => {
+          return Promise.reject(new Error('uhoh!'));
         },
       },
     });

--- a/test/loader_tests.js
+++ b/test/loader_tests.js
@@ -150,6 +150,48 @@ describe('component loader', () => {
     assert(false, 'Expected an exception');
   });
 
+  it('should fail when a sync setup function fails', async () => {
+    let load = subject({
+      fail: {
+        requires: [],
+        setup: () => {
+          throw new Error('uhoh!');
+        },
+      },
+    });
+
+    try {
+      await load('fail');
+    } catch (e) {
+      if (!e.message.match(/uhoh!/)) {
+        throw e;
+      }
+      return; // Ignore expected error
+    }
+    assert(false, 'Expected an exception');
+  });
+
+  it('should fail when an async setup function fails', async () => {
+    let load = subject({
+      fail: {
+        requires: [],
+        setup: async () => {
+          throw new Error('uhoh!');
+        },
+      },
+    });
+
+    try {
+      await load('fail');
+    } catch (e) {
+      if (!e.message.match(/uhoh!/)) {
+        throw e;
+      }
+      return; // Ignore expected error
+    }
+    assert(false, 'Expected an exception');
+  });
+
   it('should detect and bail on cyclic dependency', async () => {
     try {
       let load = subject({


### PR DESCRIPTION
When an error occurs running the setup function of a component, we want
to print out debugging information so that we can figure out that the
loading failed and at which point the loading failed.

This would be done in favour of #19 